### PR TITLE
feat: Open Graph 메타데이터에 회사 로고 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,16 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/',
   },
+  openGraph: {
+    type: 'website',
+    locale: 'en_AU',
+    siteName: 'Jay & Anna Cleaning Service Sydney',
+    images: ['/logo/logo.png'],
+  },
+  twitter: {
+    card: 'summary',
+    images: ['/logo/logo.png'],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,10 +49,18 @@ export const metadata: Metadata = {
     description: 'Premium cleaning services in Sydney. House cleaning, office cleaning, window cleaning, deep cleaning & regular cleaning across South & South-Western Sydney.',
     images: [
       {
+        url: '/logo/logo.png',
+        width: 1200,
+        height: 630,
+        alt: 'Jay & Anna Cleaning Service Sydney - Professional Cleaners',
+        type: 'image/png',
+      },
+      {
         url: '/images/main.jpg',
         width: 1200,
         height: 630,
         alt: 'Jay & Anna Professional Cleaning Service Sydney',
+        type: 'image/jpeg',
       },
     ],
   },
@@ -60,7 +68,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Jay & Anna Cleaning Service Sydney | Professional House & Office Cleaning',
     description: 'Premium cleaning services in Sydney. Get your free quote today!',
-    images: ['/images/main.jpg'],
+    images: ['/logo/logo.png'],
   },
   alternates: {
     canonical: 'https://jayannacleaningservice.com.au',


### PR DESCRIPTION
- 링크 공유시 회사 로고가 미리보기로 표시되도록 설정
- 메인 OG 이미지를 회사 로고로 변경 (/logo/logo.png)
- Twitter Cards에도 로고 이미지 적용
- 백업 이미지로 메인 사진 유지
- 카카오톡, 페이스북, 인스타그램 등 링크 공유 최적화
